### PR TITLE
.trim() was on the wrong line

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ var lov = require( 'lov' );
 
 let schema = {
 
-    id: lov.string().uuid().trim().required(),
+    id: lov.string().uuid().required(),
 
-    name: lov.string().min( 1 ).max( 100 ).required(),
+    name: lov.string().trim().min(1).max(100).required(),
 
-    age: lov.number().min( 0 ).max( 120 ),
+    age: lov.number().min(0).max(120),
 
     address: lov.object().keys( {
 


### PR DESCRIPTION
Also, how about adding a comment on whether 'a '.trim().min(2) behaves differently from 'a '.min(2).trim()  ? (I've not tested myself. Best programmer experience is likely if both variations are the same.)